### PR TITLE
 login & dashboard components now rendering based on session storage …

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,10 +1,13 @@
 import { Route } from "react-router-dom";
 import React from "react";
+import Banner from "./banner/Banner";
 import ArticleList from "./article/ArticleList";
 import MessageList from "./message/MessageList";
 import TaskList from "./task/TaskList";
 
-const Dashboard = () => {
+const Dashboard = (props) => {
+	const hasUser = props.hasUser;
+	const setUser = props.setUser;
     return (
 		<React.Fragment>
 
@@ -12,6 +15,7 @@ const Dashboard = () => {
 				exact path="/"
 				render={props => {
 					return <> 
+					<Banner {...props} setUser={setUser} hasUser={hasUser} />
                     <MessageList {...props} />
 					<ArticleList
 					{ ...props } />

--- a/src/components/Nutshell.js
+++ b/src/components/Nutshell.js
@@ -1,33 +1,35 @@
-import React from "react";
+import React, {useState} from "react";
 import Dashboard from "./Dashboard";
 import "./Nutshell.css";
-//import Login from "./auth/Login"
+import Login from "./auth/Login"
 
-
-
-// const Nutshell = (props) => {
-
-//   const isAuthenticated = () => 
-//   sessionStorage.getItem("credentials") !== null;
-  
-// return (
-//     <>
-//           {isAuthenticated ? <Dashboard {...props} /> : <Login {...props}/>}
-          
-
-//     </>
-//   );
-// };
-
-// export default Nutshell;
 
 const Nutshell = (props) => {
+  //Boolean value, false if session storage does not have credentials, true if session storage does contain credentials
+  const isAuthenticated = () => 
+sessionStorage.getItem("credentials") !== null;
+
+//user state passed along to components to verify user is authenticated
+const [hasUser, setHasUser] = useState(isAuthenticated());
+
+//function that returns the Login.js result and sets it into session storage.
+const setUser = user => {
+  sessionStorage.setItem("credentials", JSON.stringify(user));
+  setHasUser(isAuthenticated());
+  console.log(isAuthenticated())
+};
+
+//function to determine component to render based on boolean value of isAuthenticated
+// function invoked in the return 
+//Created by Brett Stoudt
+const vantagePoint = () => {
+  if (!isAuthenticated()) {
+    return <Login {...props} setUser={setUser}/>
+  } else {return <Dashboard {...props} hasUser={hasUser} />}
+}
 return (
     
-    <>
-      <Dashboard
-      { ...props } />
-    </>
+    vantagePoint()
   );
 };
 

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -13,11 +13,9 @@ const Login = props => {
         //storing email and password that User enters into session storage without database information at this step
   const handleLogin = (e) => {
     e.preventDefault();
+    console.log(credentials)
+    props.setUser(credentials);
 
-    sessionStorage.setItem(
-      "credentials",
-      JSON.stringify(credentials)
-    );
   }
 
 

--- a/src/components/banner/Banner.js
+++ b/src/components/banner/Banner.js
@@ -1,15 +1,14 @@
 import React from "react";
 import "./Banner.css"
+//import Login from "../auth/Login"
 
 
 const Banner = props => {
-         //clear the user then change the URL
-  const handleLogout = () => {
-        //came from the parent in dashboard.js
-    props.clearUser();
-    props.history.push('/');
-  }
-
+ //Log out button clears session storage
+  const handleLogout = (props) => {
+		sessionStorage.clear();
+		// {<Login />}
+	  }
   return (
     <header>
 


### PR DESCRIPTION
# Description : #1
Added Content to banner.js, nutshell.js, login.js
Login & Dashboard now render based on if conditional that is passed through the return by invoking the function.
Login sets session storage which enables dashboard.js to be viewed
Banner with Logout button now appear in dashboard after logging in.


## Type of change Added POST methods
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Testing Instructions
after loading new branch,  enter email and password into log-in fields, hit submit and your credentials will be added to the session storage. Now a conditional statement on the login & dashboard will cause a re-render of components to render dashboard.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works

